### PR TITLE
Fix nginx mkcert script

### DIFF
--- a/setup-nginx-mkcert.sh
+++ b/setup-nginx-mkcert.sh
@@ -154,6 +154,12 @@ if [ -L /etc/nginx/sites-enabled/port-forward ]; then
     sudo rm /etc/nginx/sites-enabled/port-forward
 fi
 
+# Disable the default nginx site to prevent duplicate default_server errors
+if [ -L /etc/nginx/sites-enabled/default ]; then
+    sudo rm /etc/nginx/sites-enabled/default
+    echo "Disabled default nginx site"
+fi
+
 # Enable the SSL configuration
 sudo ln -sf /etc/nginx/sites-available/port-forward-ssl /etc/nginx/sites-enabled/port-forward-ssl
 


### PR DESCRIPTION
## Summary
- disable the default nginx site in setup-nginx-mkcert.sh to avoid duplicate `default_server` errors

## Testing
- `shellcheck setup-nginx-mkcert.sh`

------
https://chatgpt.com/codex/tasks/task_e_6873206ccd508321a3724916d37fcbde